### PR TITLE
Route#pathHelp: append trailing object parameter as query string

### DIFF
--- a/lib/Route.js
+++ b/lib/Route.js
@@ -18,6 +18,8 @@ var _utils = require('./utils');
 
 var _utils2 = _interopRequireDefault(_utils);
 
+var _qs = require('qs');
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 /**
@@ -84,14 +86,10 @@ class Route {
       params[_key] = arguments[_key];
     }
 
-    let p = this.path;
-    const matches = p.match(/:[a-z]+[0-9a-zA-Z_]+/g);
-    if (matches) {
-      matches.forEach((m, i) => {
-        p = p.replace(m, params[i]);
-      });
-    }
-    return p;
+    const matches = this.path.match(/:[a-z]+[0-9a-zA-Z_]+/g);
+    const qs = params.slice(matches.length).shift();
+    const path = matches.reduce((a, b, i) => a.replace(b, params[i]), this.path);
+    return qs ? [path, (0, _qs.stringify)(qs)].join('?') : path;
   }
 
 }

--- a/lib/Route.js
+++ b/lib/Route.js
@@ -87,9 +87,10 @@ class Route {
     }
 
     const matches = this.path.match(/:[a-z]+[0-9a-zA-Z_]+/g) || [];
-    const qs = params.slice(matches.length).shift();
-    const path = matches.reduce((a, b, i) => a.replace(b, params[i]), this.path);
-    return qs ? [path, (0, _qs.stringify)(qs)].join('?') : path;
+    const args = matches.map((m, i) => params[i]).map(p => _lodash2.default.isObject(p) && !_lodash2.default.isEmpty(p) ? undefined : p).filter(p => !_lodash2.default.isUndefined(p));
+    const hash = params.slice(args.length).shift();
+    const path = matches.reduce((a, b, i) => a.replace(b, args[i]), this.path);
+    return hash ? [path, (0, _qs.stringify)(hash)].join('?') : path;
   }
 
 }

--- a/lib/Route.js
+++ b/lib/Route.js
@@ -86,7 +86,7 @@ class Route {
       params[_key] = arguments[_key];
     }
 
-    const matches = this.path.match(/:[a-z]+[0-9a-zA-Z_]+/g);
+    const matches = this.path.match(/:[a-z]+[0-9a-zA-Z_]+/g) || [];
     const qs = params.slice(matches.length).shift();
     const path = matches.reduce((a, b, i) => a.replace(b, params[i]), this.path);
     return qs ? [path, (0, _qs.stringify)(qs)].join('?') : path;

--- a/lib/Route.js
+++ b/lib/Route.js
@@ -87,10 +87,10 @@ class Route {
     }
 
     const matches = this.path.match(/:[a-z]+[0-9a-zA-Z_]+/g) || [];
-    const args = matches.map((m, i) => params[i]).map(p => _lodash2.default.isObject(p) && !_lodash2.default.isEmpty(p) ? undefined : p).filter(p => !_lodash2.default.isUndefined(p));
-    const hash = params.slice(args.length).shift();
-    const path = matches.reduce((a, b, i) => a.replace(b, args[i]), this.path);
-    return hash ? [path, (0, _qs.stringify)(hash)].join('?') : path;
+    const hash = params[params.length - 1];
+    const isObj = _lodash2.default.isObject(hash) && !_lodash2.default.isEmpty(hash);
+    const path = matches.reduce((a, b, i) => a.replace(b, params[i]), this.path);
+    return isObj ? [path, (0, _qs.stringify)(hash)].join('?') : path;
   }
 
 }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "debug": "^2.2.0",
     "lodash": "^3.10.1",
     "methods": "^1.1.1",
-    "pluralize": "^1.2.1"
+    "pluralize": "^1.2.1",
+    "qs": "^6.1.0"
   },
   "files": [
     "LICENSE",

--- a/src/Route.js
+++ b/src/Route.js
@@ -8,6 +8,7 @@
 
 import _ from 'lodash'
 import utils from './utils'
+import { stringify } from 'qs'
 
 /**
  * Route
@@ -71,14 +72,10 @@ export default class Route {
   }
 
   pathHelp(...params) {
-    let p = this.path
-    const matches = p.match(/:[a-z]+[0-9a-zA-Z_]+/g)
-    if (matches) {
-      matches.forEach((m, i) => {
-        p = p.replace(m, params[i])
-      })
-    }
-    return p
+    const matches = this.path.match(/:[a-z]+[0-9a-zA-Z_]+/g)
+    const qs = params.slice(matches.length).shift()
+    const path = matches.reduce((a, b, i) => a.replace(b, params[i]), this.path)
+    return qs ? [ path, stringify(qs) ].join('?') : path;
   }
 
 }

--- a/src/Route.js
+++ b/src/Route.js
@@ -75,7 +75,7 @@ export default class Route {
     const matches = this.path.match(/:[a-z]+[0-9a-zA-Z_]+/g)
     const qs = params.slice(matches.length).shift()
     const path = matches.reduce((a, b, i) => a.replace(b, params[i]), this.path)
-    return qs ? [ path, stringify(qs) ].join('?') : path;
+    return qs ? [ path, stringify(qs) ].join('?') : path
   }
 
 }

--- a/src/Route.js
+++ b/src/Route.js
@@ -73,12 +73,10 @@ export default class Route {
 
   pathHelp(...params) {
     const matches = this.path.match(/:[a-z]+[0-9a-zA-Z_]+/g) || []
-    const args = matches.map((m, i) => params[i])
-      .map(p => _.isObject(p) && !_.isEmpty(p) ? undefined : p)
-      .filter(p => !_.isUndefined(p))
-    const hash = params.slice(args.length).shift()
-    const path = matches.reduce((a, b, i) => a.replace(b, args[i]), this.path)
-    return hash ? [ path, stringify(hash) ].join('?') : path
+    const hash = params[params.length - 1]
+    const isObj = _.isObject(hash) && !_.isEmpty(hash)
+    const path = matches.reduce((a, b, i) => a.replace(b, params[i]), this.path)
+    return isObj ? [ path, stringify(hash) ].join('?') : path
   }
 
 }

--- a/src/Route.js
+++ b/src/Route.js
@@ -72,7 +72,7 @@ export default class Route {
   }
 
   pathHelp(...params) {
-    const matches = this.path.match(/:[a-z]+[0-9a-zA-Z_]+/g)
+    const matches = this.path.match(/:[a-z]+[0-9a-zA-Z_]+/g) || []
     const qs = params.slice(matches.length).shift()
     const path = matches.reduce((a, b, i) => a.replace(b, params[i]), this.path)
     return qs ? [ path, stringify(qs) ].join('?') : path

--- a/src/Route.js
+++ b/src/Route.js
@@ -73,9 +73,12 @@ export default class Route {
 
   pathHelp(...params) {
     const matches = this.path.match(/:[a-z]+[0-9a-zA-Z_]+/g) || []
-    const qs = params.slice(matches.length).shift()
-    const path = matches.reduce((a, b, i) => a.replace(b, params[i]), this.path)
-    return qs ? [ path, stringify(qs) ].join('?') : path
+    const args = matches.map((m, i) => params[i])
+      .map(p => _.isObject(p) && !_.isEmpty(p) ? undefined : p)
+      .filter(p => !_.isUndefined(p))
+    const hash = params.slice(args.length).shift()
+    const path = matches.reduce((a, b, i) => a.replace(b, args[i]), this.path)
+    return hash ? [ path, stringify(hash) ].join('?') : path
   }
 
 }

--- a/test/RouteMapper.test.js
+++ b/test/RouteMapper.test.js
@@ -28,6 +28,7 @@ routeMapper
 
   // Example resource route (maps HTTP verbs to controller actions automatically):
   .resources('products')
+  .resource('user')
 
   // Example resource route with options:
   .resources('products', () => {

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -16,5 +16,12 @@ describe('Router#helpers', () => {
     const expected = '/photos/233/books/377/users?admin=0&francis=bacon';
     const actual = routeMapper.helpers.google_book_users(233, 377, ...qs);
     assert(expected === actual);
+  });  
+  
+  it('should stringify a sole param into a query string for a path without params', () => {
+    const qs = [ { next: 'foobar' }, { not: 'included' } ];
+    const expected = '/user?next=foobar';
+    const actual = routeMapper.helpers.user(...qs);
+    assert(expected === actual);
   });
 });

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -10,5 +10,11 @@ describe('Router#helpers', () => {
   it('should create a path by params', () => {
     assert('/photos/233/books/377/users' === routeMapper.helpers.google_book_users(233, 377));
   });
-
+  
+  it('should stringify a single trailing param into a query string', () => {
+    const qs = [ { admin: 0, francis: 'bacon' }, { not: 'included' } ];
+    const expected = '/photos/233/books/377/users?admin=0&francis=bacon';
+    const actual = routeMapper.helpers.google_book_users(233, 377, ...qs);
+    assert(expected === actual);
+  });
 });

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -11,6 +11,13 @@ describe('Router#helpers', () => {
     assert('/photos/233/books/377/users' === routeMapper.helpers.google_book_users(233, 377));
   });
   
+  it('should insert undefined when provided insufficient parameters', () => {
+    const qs = [ { admin: 0, francis: 'bacon' }, { not: 'included' } ];
+    const expected = `/photos/233/books/undefined/users?admin=0&francis=bacon`;
+    const actual = routeMapper.helpers.google_book_users(new Number(233), ...qs);
+    assert(expected === actual);
+  });
+  
   it('should stringify a single trailing param into a query string', () => {
     const qs = [ { admin: 0, francis: 'bacon' }, { not: 'included' } ];
     const expected = '/photos/233/books/377/users?admin=0&francis=bacon';

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -11,22 +11,15 @@ describe('Router#helpers', () => {
     assert('/photos/233/books/377/users' === routeMapper.helpers.google_book_users(233, 377));
   });
   
-  it('should insert undefined when provided insufficient parameters', () => {
-    const qs = [ { admin: 0, francis: 'bacon' }, { not: 'included' } ];
-    const expected = `/photos/233/books/undefined/users?admin=0&francis=bacon`;
-    const actual = routeMapper.helpers.google_book_users(new Number(233), ...qs);
-    assert(expected === actual);
-  });
-  
   it('should stringify a single trailing param into a query string', () => {
-    const qs = [ { admin: 0, francis: 'bacon' }, { not: 'included' } ];
+    const qs = [ { admin: 0, francis: 'bacon' }];
     const expected = '/photos/233/books/377/users?admin=0&francis=bacon';
     const actual = routeMapper.helpers.google_book_users(233, 377, ...qs);
     assert(expected === actual);
-  });  
+  });
   
   it('should stringify a sole param into a query string for a path without params', () => {
-    const qs = [ { next: 'foobar' }, { not: 'included' } ];
+    const qs = [ { next: 'foobar' }];
     const expected = '/user?next=foobar';
     const actual = routeMapper.helpers.user(...qs);
     assert(expected === actual);


### PR DESCRIPTION
Inspired by Phoenix's [path_helpers](http://www.phoenixframework.org/docs/routing#section-more-on-path-helpers), I took the liberty of reimplementing `Route#pathHelp` to allow the stringification of a single trailing argument (specifically, the first argument after the final matching regex argument) into a query string for the returned path. Given the following router configuration...

``` javascript
import { Router } from 'route-mapper';
const router = new Router();

router.resources('photos', { as: 'google', format: false }, () => {
  router.resources('books', () => {
    router.resources('users');
    router.get('show');
  });
});
```

We can use the router as before, specifying params for the positional matches in the path regex. We can also add a JS object after the last param argument that will be stringified using the `qs` module and appended to the path as a query string.

``` javascript
const { google_book_users } = router.helpers;

const url1 = google_book_users(233, 377);
const url2 = google_book_users(233, 377, { admin: 0, francis: 'bacon' });

console.log(url1); // /photos/233/books/377/users
console.log(url2); // /photos/233/books/377/users?admin=0&francis=bacon
```

Added several tests, but the original suite was a little hard to compare against. For proper use of the path helpers, it's a drop-in replacement, but if the end-user is putting garbage in, behavior will be inconsistent with the original module - e.g., using too few arguments along with the qs object will get you an `[Object object]` in your path instead of an `undefined`. But broadly speaking, so long as it's not already being abused, it'll work fine.

Anyway! Really love Route-Mapper, hoping this is a helpful contribution.
